### PR TITLE
Simple Collision Detection

### DIFF
--- a/core/src/com/strayvoltage/gameoff/Block.java
+++ b/core/src/com/strayvoltage/gameoff/Block.java
@@ -16,7 +16,7 @@ public class Block extends GameMapObject {
   public void init(MapProperties mp, TextureAtlas textures)
   {
 	m_categoryBits = Box2dVars.BLOCK;
-	m_filterMask = Box2dVars.PLATFORM | Box2dVars.PLAYER_NORMAL | Box2dVars.PLAYER_JUMPING | Box2dVars.PLATFORM_STOP| Box2dVars.FLOOR;
+	m_filterMask = Box2dVars.PLAYER_FOOT | Box2dVars.PLATFORM | Box2dVars.PLAYER_NORMAL | Box2dVars.PLAYER_JUMPING | Box2dVars.PLATFORM_STOP| Box2dVars.FLOOR;
     m_density = 1.5f;
     m_colBits = 3;
     TextureRegion texture = null;
@@ -29,4 +29,5 @@ public class Block extends GameMapObject {
   {
       this.setPositionToBody();
   }
+
 }

--- a/core/src/com/strayvoltage/gameoff/Box2dCollision.java
+++ b/core/src/com/strayvoltage/gameoff/Box2dCollision.java
@@ -1,0 +1,25 @@
+package com.strayvoltage.gameoff;
+
+public class Box2dCollision {
+	/**
+	 * the category bits of self.(or A)
+	 */
+	public short self_type;
+	/**
+	 * the box2dVars category bit of the target(or B)
+	 * used to identify the type of collision. 
+	 */
+	public short target_type;
+	/**
+	 * the target object which this object has made contact with.
+	 * It can be null for such things as walls which do not have 
+	 * a gameobject. in that case use 'type' to identify.
+	 */
+	public GameMapObject target;
+	
+	public Box2dCollision(short self_type,short target_type,GameMapObject target) {
+		this.self_type = self_type;
+		this.target_type = target_type;
+		this.target = target;
+	}
+}

--- a/core/src/com/strayvoltage/gameoff/Box2dCollisionAdapter.java
+++ b/core/src/com/strayvoltage/gameoff/Box2dCollisionAdapter.java
@@ -1,0 +1,78 @@
+package com.strayvoltage.gameoff;
+
+import com.badlogic.gdx.physics.box2d.Contact;
+import com.badlogic.gdx.physics.box2d.ContactImpulse;
+import com.badlogic.gdx.physics.box2d.ContactListener;
+import com.badlogic.gdx.physics.box2d.Fixture;
+import com.badlogic.gdx.physics.box2d.Manifold;
+
+public class Box2dCollisionAdapter implements ContactListener{
+	
+	Box2dCollision col;
+	
+	public Box2dCollisionAdapter() {
+		col = new Box2dCollision(Box2dVars.OBJECT,Box2dVars.OBJECT, null);
+	}
+
+	@Override
+	public void beginContact(Contact contact) {
+		Fixture a = contact.getFixtureA();
+		Fixture b = contact.getFixtureB();
+		Box2dCollisionHandler bch = null;
+		if(a.getUserData()!=null&&a.getUserData() instanceof Box2dCollisionHandler) {
+			bch = (Box2dCollisionHandler) a.getUserData();
+			col.self_type = a.getFilterData().categoryBits;
+			col.target_type = b.getFilterData().categoryBits;
+			if(b.getUserData()!=null&&b.getUserData() instanceof GameMapObject) {
+				col.target = (GameMapObject) b.getUserData();
+			}
+			bch.handleBegin(col);
+		}
+		if(b.getUserData()!=null&&b.getUserData() instanceof Box2dCollisionHandler) {
+			bch = (Box2dCollisionHandler) b.getUserData();
+			col.self_type = b.getFilterData().categoryBits;
+			col.target_type = a.getFilterData().categoryBits;
+			if(a.getUserData()!=null&&a.getUserData() instanceof GameMapObject) {
+				col.target = (GameMapObject) a.getUserData();
+			}
+			bch.handleBegin(col);
+		}
+		
+	}
+
+	@Override
+	public void endContact(Contact contact) {
+		Fixture a = contact.getFixtureA();
+		Fixture b = contact.getFixtureB();
+		Box2dCollisionHandler bch = null;
+		if(a.getUserData()!=null&&a.getUserData() instanceof Box2dCollisionHandler) {
+			bch = (Box2dCollisionHandler) a.getUserData();
+			col.self_type = a.getFilterData().categoryBits;
+			col.target_type = b.getFilterData().categoryBits;
+			if(b.getUserData()!=null&&b.getUserData() instanceof GameMapObject) {
+				col.target = (GameMapObject) b.getUserData();
+			}
+			bch.handleEnd(col);
+		}
+		if(b.getUserData()!=null&&b.getUserData() instanceof Box2dCollisionHandler) {
+			bch = (Box2dCollisionHandler) b.getUserData();
+			col.self_type = b.getFilterData().categoryBits;
+			col.target_type = a.getFilterData().categoryBits;
+			if(a.getUserData()!=null&&a.getUserData() instanceof GameMapObject) {
+				col.target = (GameMapObject) a.getUserData();
+			}
+			bch.handleEnd(col);
+		}
+	}
+
+	@Override
+	public void preSolve(Contact contact, Manifold oldManifold) {
+		
+	}
+
+	@Override
+	public void postSolve(Contact contact, ContactImpulse impulse) {
+		
+	}
+
+}

--- a/core/src/com/strayvoltage/gameoff/Box2dCollisionHandler.java
+++ b/core/src/com/strayvoltage/gameoff/Box2dCollisionHandler.java
@@ -1,0 +1,15 @@
+package com.strayvoltage.gameoff;
+
+public interface Box2dCollisionHandler {
+	/**
+	 * use it to handle contact begin
+	 * @param collision - contains collision category data and target of collision
+	 */
+	public void handleBegin(Box2dCollision collision);
+	/**
+	 * same as handleBegin only that it is used to handle 
+	 * the end of collisions. 
+	 * @param collision
+	 */
+	public void handleEnd(Box2dCollision collision);
+}

--- a/core/src/com/strayvoltage/gameoff/Box2dVars.java
+++ b/core/src/com/strayvoltage/gameoff/Box2dVars.java
@@ -15,6 +15,7 @@ public class Box2dVars {
 	public static final short HAZARD = 256;
 	public static final short FLOOR = 512;
 	public static final short OBJECT = 1024;
+	public static final short PLAYER_FOOT = 2048;
 	
 	
 

--- a/core/src/com/strayvoltage/gameoff/GameMapObject.java
+++ b/core/src/com/strayvoltage/gameoff/GameMapObject.java
@@ -24,18 +24,20 @@ public abstract class GameMapObject extends GameSprite {
   boolean m_onGround = true;
   float m_gravity = -0.2f;
   Fixture m_fixture = null;
-  short m_categoryBits = 64;
+  short m_categoryBits = Box2dVars.OBJECT;
   short m_filterMask = 255;
   float m_gravityScale = 1f;
   float m_sizeScale = 1.0f;
   boolean m_hasPhysics = true;
   float m_restitution = 0.2f;
   float m_density = 1f;
+  BodyType m_btype;
 
   public GameMapObject()
   {
     super();
     m_colBits = 0;
+    m_btype = BodyType.DynamicBody;
   }
 
   public void setMap(GameTileMap map)
@@ -81,7 +83,7 @@ public abstract class GameMapObject extends GameSprite {
     MainLayer m = (MainLayer) getParent();
     for (GameMapObject o : m.m_gameMapObjects)
     {
-      //todo: might need to add players here?
+      //TODO: might need to add players here?
       if (o != this)
       {
         if ((o.colBits() & bits) > 0)
@@ -123,7 +125,7 @@ public abstract class GameMapObject extends GameSprite {
   {
 
     BodyDef bodyDef = new BodyDef();
-    bodyDef.type = BodyType.DynamicBody;
+    bodyDef.type = m_btype;
     bodyDef.fixedRotation = true;
 
     m_body = world.createBody(bodyDef);
@@ -144,6 +146,7 @@ public abstract class GameMapObject extends GameSprite {
     fixtureDef.filter.maskBits = m_filterMask;
 
     m_fixture = m_body.createFixture(fixtureDef);
+    m_fixture.setUserData(this);
     m_body.setGravityScale(m_gravityScale);
     rect.dispose();
 

--- a/core/src/com/strayvoltage/gameoff/MainLayer.java
+++ b/core/src/com/strayvoltage/gameoff/MainLayer.java
@@ -137,7 +137,7 @@ public float getFloat(String key, MapObject mp)
     //floor is now floor lol
     fixtureDef.filter.categoryBits = Box2dVars.FLOOR;
     //i think without a mask it m eans the floor can collide with everything. This way it cant. 
-    fixtureDef.filter.maskBits = Box2dVars.BLOCK | Box2dVars.PLAYER_NORMAL | Box2dVars.PLAYER_JUMPING | Box2dVars.POWER;
+    fixtureDef.filter.maskBits = Box2dVars.PLAYER_FOOT | Box2dVars.BLOCK | Box2dVars.PLAYER_NORMAL | Box2dVars.PLAYER_JUMPING | Box2dVars.POWER;
     fixtureDef.friction = 0.5f;
     float w = 0;
     float boxY = 0;
@@ -159,14 +159,14 @@ public float getFloat(String key, MapObject mp)
         	if(chainVectors.size == 0) {
         		//setup first vertex
         		startx = tx;
-        		chainVectors.add(new Vector2(0,0));
+        		chainVectors.add(new Vector2(0,Box2dVars.PIXELS_PER_METER*.05f));
         		chainVectors.add(new Vector2(0,tilesize));
         	}
         	chainVectors.add(new Vector2((chainVectors.peek().x+tilesize),tilesize));
         }
         if((c==null||tx+1 == m_mapWidth)&&chainVectors.size>0){
         	
-        	chainVectors.add(new Vector2((chainVectors.peek().x),0));
+        	chainVectors.add(new Vector2((chainVectors.peek().x),Box2dVars.PIXELS_PER_METER*.05f));
         	bodyDef = new BodyDef();
         	bodyDef.type = BodyType.StaticBody;
         	chain = new PolygonShape();
@@ -227,6 +227,7 @@ public float getFloat(String key, MapObject mp)
       {
         world.destroyBody(b);
       }
+      world.setContactListener(null);
     }
 
     if (world == null) {
@@ -339,6 +340,11 @@ public float getFloat(String key, MapObject mp)
         }
       }
     }
+    
+    //ADD COLLISIONADAPTER After all world objects are set.
+   	world.setContactListener(new Box2dCollisionAdapter());
+	
+	
 
     //TODO: we'll add particle effects when player dies and in other spots
     /*

--- a/core/src/com/strayvoltage/gameoff/Platform.java
+++ b/core/src/com/strayvoltage/gameoff/Platform.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.graphics.g2d.*;
 import java.util.Iterator;
 import java.util.ArrayList;
 import com.badlogic.gdx.math.*;
+import com.badlogic.gdx.physics.box2d.BodyDef.BodyType;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.glutils.*;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
@@ -32,8 +33,9 @@ public class Platform extends GameMapObject {
 
   public void init(MapProperties mp, TextureAtlas textures)
   {
+	
 	m_categoryBits = Box2dVars.PLATFORM;
-	m_filterMask = Box2dVars.POWER | Box2dVars.FLOOR | Box2dVars.PLAYER_NORMAL | Box2dVars.PLAYER_JUMPING | Box2dVars.BLOCK;
+	m_filterMask = Box2dVars.PLAYER_FOOT | Box2dVars.POWER | Box2dVars.FLOOR | Box2dVars.PLAYER_NORMAL | Box2dVars.PLAYER_JUMPING | Box2dVars.BLOCK;
     m_gravityScale = 0;
     m_colBits = 3;
     m_sizeScale = 0.9f;

--- a/core/src/com/strayvoltage/gameoff/Player.java
+++ b/core/src/com/strayvoltage/gameoff/Player.java
@@ -15,7 +15,7 @@ import com.badlogic.gdx.physics.box2d.*;
 import com.badlogic.gdx.physics.box2d.BodyDef.*;
 import com.badlogic.gdx.utils.Array;
 
-public class Player extends GameSprite {
+public class Player extends GameSprite implements Box2dCollisionHandler{
 
   GameInputManager2 m_controller;
   float m_dx = 0;
@@ -83,6 +83,7 @@ public class Player extends GameSprite {
     fixtureDef.filter.maskBits = Box2dVars.FLOOR | Box2dVars.BLOCK | Box2dVars.PLATFORM;
 
     m_fixture = m_body.createFixture(fixtureDef);
+    m_fixture.setUserData(this);
     rect.dispose();
 
     fixtureDef = new FixtureDef();
@@ -94,10 +95,11 @@ public class Player extends GameSprite {
     fixtureDef.density = 0f; 
     fixtureDef.friction = 0f;
     fixtureDef.restitution = 0f;
-    fixtureDef.filter.categoryBits = Box2dVars.PLAYER_NORMAL;
+    fixtureDef.filter.categoryBits = Box2dVars.PLAYER_FOOT; //changed to foot so we can do separate collision testing. 
     fixtureDef.filter.maskBits = Box2dVars.FLOOR | Box2dVars.BLOCK | Box2dVars.PLATFORM;
 
-		playerSensorFixture = m_body.createFixture(fixtureDef);
+	playerSensorFixture = m_body.createFixture(fixtureDef);
+	playerSensorFixture.setUserData(this);
     playerSensorFixture.setSensor(true);		
 		circle.dispose();		
 		
@@ -386,6 +388,40 @@ public class Player extends GameSprite {
   {
     return true;
   }
+
+  
+  /////COLLISION HANDLING EXAMPLE -------------------------------
+  	//NOTE: in order to make any changes to the physics world or any physics related object
+    //		be sure to call Gdx.app.postRunnable() or you will stall the thread. 
+	@Override
+	public void handleBegin(Box2dCollision collision) {
+		//only check the collision of the player foot not the body. 
+		if(collision.self_type == Box2dVars.PLAYER_FOOT) {
+			//the collision target type is the type(categoryBits) of the thing we are colliding with. 
+			
+			Gdx.app.log("PlayerContactTest:","Target Collision Category="+collision.target_type);
+			
+			if(collision.target_type == Box2dVars.FLOOR) {
+				Gdx.app.log("PlayerContactTest:", "we touched a FLOOR!");
+			}
+			
+			//if the collision target is another gameMapObject we can access it from here
+			//i thought of removing this and just implementing it as Object and letting the programmer
+			//cast it themselves whenever they need to but this is simpler for now. 
+			if(collision.target!=null) {
+				//do stuff with the collision target
+				GameMapObject obj = collision.target;
+			}
+		}
+		
+		
+		
+	}
+	
+	@Override
+	public void handleEnd(Box2dCollision collision) {
+		
+	}
   
 }
 


### PR DESCRIPTION
Impletented a simple way we can do collision detection and added a small example in the player object.

Basically you just implement the Box2dCollisionHandler Interface on any objects that you add to the world that you want to handle collision for.

Then it is a matter of just using the category data(or type) to filter out results and react accordingly.

Also fixed a bug where the small player could not go through small passage ways.